### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/data.py
+++ b/data.py
@@ -10,6 +10,6 @@ def hello():
 
 if __name__ == "__main__":
     
-    port = os.getenv('VCAP_APP_PORT', '5000')
+    port = os.getenv('PORT', '5000')
     
     app.run(port=int(port), host='0.0.0.0')


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.
